### PR TITLE
feat: 업비트 api를 통해 00시 비트코인 기준가 업데이트 로직 구현

### DIFF
--- a/src/main/java/com/BitOracle/BitOracle/config/SecurityConfig.java
+++ b/src/main/java/com/BitOracle/BitOracle/config/SecurityConfig.java
@@ -94,7 +94,8 @@ public class SecurityConfig {
                                 "/", "/reissue", "/api/auth/init",   // 기본 허용
                                 "/v3/api-docs/**",                       // Swagger 문서 JSON
                                 "/swagger-ui/**", "/swagger-ui.html",    // Swagger UI
-                                "/swagger-resources/**", "/webjars/**"   // Swagger 리소스
+                                "/swagger-resources/**", "/webjars/**",   // Swagger 리소스
+                                "/api/predict/midnight"             // 로그인 상관 없이 허용되는 api
                         ).permitAll()
                         .anyRequest().authenticated()
                 );

--- a/src/main/java/com/BitOracle/BitOracle/converter/BtcPriceConverter.java
+++ b/src/main/java/com/BitOracle/BitOracle/converter/BtcPriceConverter.java
@@ -11,6 +11,7 @@ public class BtcPriceConverter {
 
     public static BtcPriceResponseDto.BtcPriceMidnightResponseDto toBtcPriceMidnightResponseDto (BtcPrice btcPrice){
         return BtcPriceResponseDto.BtcPriceMidnightResponseDto.builder()
+                .today(btcPrice.getCoinDate())
                 .price(btcPrice.getPrice())
                 .build();
     }

--- a/src/main/java/com/BitOracle/BitOracle/domain/BtcPrice.java
+++ b/src/main/java/com/BitOracle/BitOracle/domain/BtcPrice.java
@@ -5,8 +5,6 @@ import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/com/BitOracle/BitOracle/dto/BtcPriceResponseDto.java
+++ b/src/main/java/com/BitOracle/BitOracle/dto/BtcPriceResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 public class BtcPriceResponseDto {
     @Builder
@@ -13,6 +14,7 @@ public class BtcPriceResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class BtcPriceMidnightResponseDto {
+        LocalDate today;
         BigDecimal price;
     }
 }

--- a/src/main/java/com/BitOracle/BitOracle/service/BtcPriceService.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/BtcPriceService.java
@@ -2,11 +2,20 @@ package com.BitOracle.BitOracle.service;
 
 import com.BitOracle.BitOracle.domain.BtcPrice;
 import com.BitOracle.BitOracle.repository.BtcPriceRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 @RequiredArgsConstructor
 @Service
@@ -17,6 +26,44 @@ public class BtcPriceService {
     public BtcPrice getMidnightBtc(){
         LocalDate today = LocalDate.now();
         log.info("Today is {}", today);
-        return btcPriceRepository.findByCoinDate(today);
+
+        // 1. DB에 이미 있다면 DB에서 가져옴
+        BtcPrice btcPrice = btcPriceRepository.findByCoinDate(today);
+        if (btcPrice != null) {
+            log.info("Found price in DB: {}", btcPrice.getPrice());
+            return btcPrice;
+        }
+
+        try {
+            // 2. 업비트 API 호출 (금일 00시 기준 가격)
+            ZonedDateTime todayMidnightKst = today.atStartOfDay(ZoneId.of("Asia/Seoul"));
+            String toDate = todayMidnightKst.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")); // RFC3339
+
+            String url = "https://api.upbit.com/v1/candles/days?market=KRW-BTC&count=1&to=" + toDate;
+            log.info("요청할 URL: {}", url);
+
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(response.getBody());
+            JsonNode candle = root.get(0);
+
+            BigDecimal openingPrice = candle.get("opening_price").decimalValue();
+
+            // 3. DB에 저장
+            BtcPrice newPrice = BtcPrice.builder()
+                    .coinDate(today)
+                    .price(openingPrice)
+                    .build();
+
+            btcPriceRepository.save(newPrice);
+            log.info("Saved new BTC Date: {}, price: {}", today, openingPrice);
+
+            return newPrice;
+        } catch (Exception e) {
+            log.error("Error while calling Upbit API", e);
+            throw new RuntimeException("업비트 API 호출 실패", e);
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #22 

## 📝작업 내용

> 00시 비트코인 기준가 조회
> db에 이미 있다면 바로 리턴
> db에 없다면 업비트 api를 통해 가져와 db에 저장 후 리턴

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?