### PR TITLE
feat: 경제 뉴스 - chatGPT - DB 파이프라인 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,12 @@ dependencies {
 	//S3 아마존
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	// jsoup
+	implementation 'org.jsoup:jsoup:1.18.1'
+
+	// WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/BitOracle/BitOracle/config/SecurityConfig.java
+++ b/src/main/java/com/BitOracle/BitOracle/config/SecurityConfig.java
@@ -95,7 +95,7 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",                       // Swagger 문서 JSON
                                 "/swagger-ui/**", "/swagger-ui.html",    // Swagger UI
                                 "/swagger-resources/**", "/webjars/**",   // Swagger 리소스
-                                "/api/predict/midnight"   ,          // 로그인 상관 없이 허용되는 api
+                                "/api/predict/midnight", "/api/test/**",          // 로그인 상관 없이 허용되는 api
                                 "/api/community/**",
                                 "/ws-upbit/**"
                         ).permitAll()

--- a/src/main/java/com/BitOracle/BitOracle/config/WebClientConfig.java
+++ b/src/main/java/com/BitOracle/BitOracle/config/WebClientConfig.java
@@ -1,0 +1,46 @@
+package com.BitOracle.BitOracle.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+//    @Bean
+//    public WebClient webClient() {
+//        return WebClient.builder()
+//                .baseUrl("https://kr.investing.com")  // 기본 도메인
+//                .defaultHeader("User-Agent", "Mozilla/5.0 (compatible)")
+//                .build();
+//    }
+
+    @Bean
+    @Qualifier("openAiClient")
+    public WebClient openAiClient() {
+        return WebClient.builder()
+                .baseUrl("https://api.openai.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    @Bean
+    @Qualifier("cryptoPanicClient")
+    public WebClient cryptoPanicClient() {
+        return WebClient.builder()
+                .baseUrl("https://cryptopanic.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    @Bean
+    @Qualifier("deepSearchClient")
+    public WebClient deepSearchClient() {
+        return WebClient.builder()
+                .baseUrl("https://api-v2.deepsearch.com")
+                .build();
+    }
+}

--- a/src/main/java/com/BitOracle/BitOracle/controller/TestController.java
+++ b/src/main/java/com/BitOracle/BitOracle/controller/TestController.java
@@ -1,15 +1,26 @@
 package com.BitOracle.BitOracle.controller;
 
+import com.BitOracle.BitOracle.service.RunNewsPipeline;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api")
+@RequestMapping("/api/test")
 @RestController
+@RequiredArgsConstructor
 public class TestController {
+
+    private final RunNewsPipeline runNewsPipeline;
 
     @GetMapping("/auth/test")
     public String testLogin() {
         return "✅ 로그인된 사용자입니다.";
+    }
+
+    @GetMapping("/run-news-pipeline")
+    public String runNewsPipelineNow() throws InterruptedException {
+        runNewsPipeline.runNewsPipeline();
+        return "뉴스 파이프라인 실행 완료!";
     }
 }

--- a/src/main/java/com/BitOracle/BitOracle/domain/News.java
+++ b/src/main/java/com/BitOracle/BitOracle/domain/News.java
@@ -1,6 +1,6 @@
 package com.BitOracle.BitOracle.domain;
 
-import com.BitOracle.BitOracle.domain.enums.PostType;
+import com.BitOracle.BitOracle.domain.enums.NewsType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -21,7 +21,9 @@ public class News {
     private String  newsContent;
     @Column(name = "news_url")
     private String newsUrl;
-    @Column(name = "post_type")
+    @Column(name = "image_url")
+    private String imageUrl;
+    @Column(name = "news_type")
     @Enumerated(EnumType.STRING)
-    private PostType postType;
+    private NewsType newsType;
 }

--- a/src/main/java/com/BitOracle/BitOracle/dto/CrawledNewsDto.java
+++ b/src/main/java/com/BitOracle/BitOracle/dto/CrawledNewsDto.java
@@ -1,0 +1,17 @@
+package com.BitOracle.BitOracle.dto;
+
+import com.BitOracle.BitOracle.domain.enums.NewsType;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CrawledNewsDto {
+    private String title;
+    private String url;
+    private String summary;
+    private String imageUrl;
+    private NewsType newsType;
+}

--- a/src/main/java/com/BitOracle/BitOracle/repository/NewsRepository.java
+++ b/src/main/java/com/BitOracle/BitOracle/repository/NewsRepository.java
@@ -1,0 +1,8 @@
+package com.BitOracle.BitOracle.repository;
+
+import com.BitOracle.BitOracle.domain.News;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsRepository extends JpaRepository<News, Long> {
+    boolean existsByNewsUrl(String newsUrl);
+}

--- a/src/main/java/com/BitOracle/BitOracle/service/CryptoPanicNewsCrawler.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/CryptoPanicNewsCrawler.java
@@ -1,0 +1,62 @@
+package com.BitOracle.BitOracle.service;
+
+import com.BitOracle.BitOracle.dto.CrawledNewsDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+// CryptoPanic은 자체 사이트에서 뉴스 api를 제공해주지만 영어 뉴스이고, 이미지가 없기 때문에 우리 서비스와 적합하지 않아서 현재는 사용하지 않음
+public class CryptoPanicNewsCrawler {
+
+    @Value("${spring.cryptopanic.key}")
+    private String apiKey;
+
+    private final @Qualifier("cryptoPanicClient") WebClient cryptoPanicClient;
+
+    public List<CrawledNewsDto> fetchNews() {
+        String response = cryptoPanicClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/api/v1/posts/")
+                        .queryParam("auth_token", apiKey)
+                        .queryParam("currencies", "BTC")
+                        .queryParam("public", "true")
+                        .build())
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        List<CrawledNewsDto> result = new ArrayList<>();
+
+        try {
+            var jsonNode = new com.fasterxml.jackson.databind.ObjectMapper().readTree(response);
+            var articles = jsonNode.get("results");
+
+            for (var article : articles) {
+                String title = article.get("title").asText();
+                String url = article.get("url").asText();
+                String summary = article.has("content") && !article.get("content").isNull() ? article.get("content").asText() : "";
+                String imageUrl = article.has("thumbnail") && !article.get("thumbnail").isNull() ? article.get("thumbnail").asText() : null;
+
+                result.add(CrawledNewsDto.builder()
+                        .title(title)
+                        .url(url)
+                        .summary(summary)
+                        .imageUrl(imageUrl)
+                        .build());
+            }
+        } catch (Exception e) {
+            log.error("CryptoPanic 응답 파싱 실패", e);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/BitOracle/BitOracle/service/DeepSearchNewsCrawler.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/DeepSearchNewsCrawler.java
@@ -1,0 +1,75 @@
+package com.BitOracle.BitOracle.service;
+
+import com.BitOracle.BitOracle.dto.CrawledNewsDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class DeepSearchNewsCrawler {
+
+    private final WebClient deepSearchClient;
+
+    @Value("${spring.deepsearch.key}")
+    private String deepSearchKey;
+
+    public List<CrawledNewsDto> fetchNews() {
+        String keyword = "비트코인 OR 블록체인 OR 암호화폐 OR 가상화폐"; // 키워드 조정 가능
+
+        Mono<String> responseMono = deepSearchClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v1/global-articles")
+                        .queryParam("keyword", keyword)
+                        .queryParam("page_size", 20)
+                        .queryParam("api_key", deepSearchKey)
+                        .build())
+                .retrieve()
+                .bodyToMono(String.class);
+
+        String response = responseMono.block(); // 비동기 처리 필요 시 조정 가능
+        log.info("딥서치 응답: {}", response);
+
+        return parse(response);
+    }
+
+    public List<CrawledNewsDto> parse(String json) {
+        List<CrawledNewsDto> result = new ArrayList<>();
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(json);
+            JsonNode data = root.get("data");
+
+            for (JsonNode node : data) {
+                String title = node.get("title_ko").asText();
+                String summary = node.get("summary_ko").asText();
+                String url = node.get("content_url").asText();
+                String imageUrl = node.get("image_url").isNull() ? null : node.get("image_url").asText();
+
+                CrawledNewsDto dto = CrawledNewsDto.builder()
+                        .title(title)
+                        .summary(summary)
+                        .url(url)
+                        .imageUrl(imageUrl)
+                        .build();
+
+                result.add(dto);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return result;
+    }
+}
+

--- a/src/main/java/com/BitOracle/BitOracle/service/OpenAiService.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/OpenAiService.java
@@ -1,0 +1,48 @@
+package com.BitOracle.BitOracle.service;
+
+import com.BitOracle.BitOracle.domain.enums.NewsType;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class OpenAiService {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenAiService.class);
+    @Value("${spring.openai.secret}")
+    private String openaiKey;
+    private final @Qualifier("openAiClient") WebClient openAiClient;
+
+    public NewsType classifyNews(String title, String summary) {
+        String prompt = String.format("""
+                아래 코인 뉴스는 호재인지 악재인지 분류해줘.
+                결과는 반드시 '호재' 또는 '악재'로만 줘.
+                제목: %s
+                요약: %s
+                """, title, summary);
+
+        String response = openAiClient.post()
+                .uri("/v1/chat/completions")
+                .header("Authorization", "Bearer " + openaiKey)
+                .bodyValue(Map.of(
+                        "model", "gpt-3.5-turbo",
+                        "messages", List.of(
+                                Map.of("role", "user", "content", prompt)
+                        )
+                ))
+                .retrieve()
+                .bodyToMono(String.class)
+                .doOnNext(body -> log.warn("OpenAI 응답: {}", body))  // 여기에 로그 찍기
+                .block();
+
+        return response.contains("호재") ? NewsType.GOOD : NewsType.BAD;
+    }
+}

--- a/src/main/java/com/BitOracle/BitOracle/service/RunNewsPipeline.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/RunNewsPipeline.java
@@ -1,0 +1,64 @@
+package com.BitOracle.BitOracle.service;
+
+import com.BitOracle.BitOracle.domain.News;
+import com.BitOracle.BitOracle.domain.enums.NewsType;
+import com.BitOracle.BitOracle.dto.CrawledNewsDto;
+import com.BitOracle.BitOracle.repository.NewsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RunNewsPipeline {
+
+    private final DeepSearchNewsCrawler crawler;
+    private final OpenAiService openAiService;
+    private final NewsRepository newsRepository;
+
+    @Scheduled(cron = "0 0 1 * * *") // 매일 01시 실행
+    public void runNewsPipeline() {
+        List<CrawledNewsDto> allNews = crawler.fetchNews();
+
+        List<News> bullish = new ArrayList<>();
+        List<News> bearish = new ArrayList<>();
+
+        for (CrawledNewsDto dto : allNews) {
+            // 이미 있는 URL이면 패스
+            if (newsRepository.existsByNewsUrl(dto.getUrl())) {
+                log.info("이미 저장된 뉴스입니다: {}", dto.getUrl());
+                continue;
+            }
+
+            NewsType type = openAiService.classifyNews(dto.getTitle(), dto.getSummary());
+
+            // ✂ 요약 내용이 너무 길면 자르기
+            String trimmedSummary = dto.getSummary();
+            if (trimmedSummary.length() > 255) {
+                trimmedSummary = trimmedSummary.substring(0, 255);
+            }
+
+            News news = News.builder()
+                    .newsTitle(dto.getTitle())
+                    .newsUrl(dto.getUrl())
+                    .newsContent(trimmedSummary)
+                    .imageUrl(dto.getImageUrl())
+                    .newsType(type)
+                    .build();
+
+            if (type == NewsType.GOOD && bullish.size() < 3) bullish.add(news);
+            if (type == NewsType.BAD && bearish.size() < 3) bearish.add(news);
+
+            if (bullish.size() == 3 && bearish.size() == 3) break;
+        }
+
+        newsRepository.saveAll(bullish);
+        newsRepository.saveAll(bearish);
+        log.info("뉴스 저장 완료. 호재: {}, 악재: {}", bullish.size(), bearish.size());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,15 @@ spring:
   jwt:
     secret: vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
 
+  openai:
+    secret: ${OPEN_AI_KEY}
+
+  cryptopanic:
+    key: ${CRYPTOPANIC_KEY}
+
+  deepsearch:
+    key: ${DEEPSEARCH_KEY}
+
   security:
     oauth2:
       client:
@@ -62,7 +71,7 @@ spring:
       region:
         static: ap-northeast-2  # 버킷의 리전
       s3:
-        bucket: bit-oracle-bucket  # 버킷 이름
+        bucket: bitoracle-bucket  # 버킷 이름
       stack:
         auto: false
   servlet:


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #27 

## 📝작업 내용

> 1. DeepSearchNewsCrawler에서 DeepSearch API를 이용해 "비트코인 OR 블록체인 OR 암호화폐 OR 가상화폐" 키워드로
> 해외 뉴스 20개를 가져옴
> 2. 가져온 뉴스의 제목과 내용을 chatGPT에게 넘겨 호재인지 악재인지 판단
> 3. 호재/악재 여부와 뉴스 제목, 내용, 이미지, url을 DB에 저장 (새벽 1시에 스케줄링, 테스트 컨트롤러도 구현)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?