### PR TITLE
feat : 댓글 + 대댓글구현(서비스코드만 작성)

### DIFF
--- a/src/main/java/com/BitOracle/BitOracle/config/S3Config.java
+++ b/src/main/java/com/BitOracle/BitOracle/config/S3Config.java
@@ -6,7 +6,9 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
+@Profile("!test")
 @Configuration
 public class S3Config {
 

--- a/src/main/java/com/BitOracle/BitOracle/config/SecurityConfig.java
+++ b/src/main/java/com/BitOracle/BitOracle/config/SecurityConfig.java
@@ -97,7 +97,8 @@ public class SecurityConfig {
                                 "/swagger-resources/**", "/webjars/**",   // Swagger 리소스
                                 "/api/predict/midnight"   ,          // 로그인 상관 없이 허용되는 api
                                 "/api/community/**",
-                                "/ws-upbit/**"
+                                "/ws-upbit/**",
+                                "/api/reply/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 );

--- a/src/main/java/com/BitOracle/BitOracle/controller/PostController.java
+++ b/src/main/java/com/BitOracle/BitOracle/controller/PostController.java
@@ -2,9 +2,7 @@ package com.BitOracle.BitOracle.controller;
 
 import com.BitOracle.BitOracle.domain.User;
 import com.BitOracle.BitOracle.domain.UserEntity;
-import com.BitOracle.BitOracle.dto.PostResDto;
-import com.BitOracle.BitOracle.dto.PostSaveReqDto;
-import com.BitOracle.BitOracle.dto.PostSaveResDto;
+import com.BitOracle.BitOracle.dto.*;
 import com.BitOracle.BitOracle.repository.UserRepository;
 import com.BitOracle.BitOracle.response.DataResponseDto;
 import com.BitOracle.BitOracle.service.PostService;
@@ -31,7 +29,9 @@ public class PostController {
     private final UserRepository userRepository;
 
     @PostMapping(value = "/post",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public DataResponseDto<PostSaveResDto> savePost(@RequestPart(value = "post") @Parameter(schema =@Schema(type = "string", format = "binary")) PostSaveReqDto postSaveReqDto, @RequestPart(value = "images",required = false) List<MultipartFile> images)
+    public DataResponseDto<PostSaveResDto> savePost(@RequestPart(value = "post") @Parameter(schema =@Schema(type = "string", format = "binary")) PostSaveReqDto postSaveReqDto,
+                                                    @RequestPart(value = "images",required = false) List<MultipartFile> images
+                                                    )
     {
         User user = User.builder()
                 .userName("진서")
@@ -46,10 +46,15 @@ public class PostController {
     public DataResponseDto<Page<PostResDto>> getAllPosts(@RequestParam(defaultValue = "0",name = "page")int page,
                                                          @RequestParam(defaultValue = "10",name = "size") int size,
                                                          @RequestParam(defaultValue = "createdAt",name="sortBy") String sortBy,
-                                                         @RequestParam(defaultValue = "desc",name="desc") String direction){
+                                                         @RequestParam(defaultValue = "desc",name="direction") String direction){
         Sort sort = direction.equalsIgnoreCase("desc") ? Sort.by(sortBy).descending() : Sort.by(sortBy).ascending();
         Pageable pageable = PageRequest.of(page, size, sort);
         Page<PostResDto> posts = postService.findAll(pageable);
         return DataResponseDto.of(posts,"전체 글 조회@@");
     }
+
+    //댓글 추가
+    //@PostMapping("/post/{postId}/comment")
+
+
 }

--- a/src/main/java/com/BitOracle/BitOracle/controller/Replycontroller.java
+++ b/src/main/java/com/BitOracle/BitOracle/controller/Replycontroller.java
@@ -1,0 +1,34 @@
+package com.BitOracle.BitOracle.controller;
+
+import com.BitOracle.BitOracle.domain.Reply;
+import com.BitOracle.BitOracle.dto.ReplyResDto;
+import com.BitOracle.BitOracle.dto.ReplySaveReqDto;
+import com.BitOracle.BitOracle.response.DataResponseDto;
+import com.BitOracle.BitOracle.service.ReplyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/reply")
+@RestController
+@RequiredArgsConstructor
+public class Replycontroller {
+    private final ReplyService replyService;
+
+    @PostMapping("/{postId}")
+    public DataResponseDto<ReplyResDto> replySave(@PathVariable(name = "postId") Long postId, ReplySaveReqDto replySaveReqDto){
+        Reply reply = replyService.saveReply(postId, replySaveReqDto);
+        ReplyResDto replyResDto = ReplyResDto.builder()
+                .replyId(reply.getReplyId())
+                .createdAt(reply.getCreatedAt())
+                .content(reply.getReplyContent())
+                .postId(reply.getPost().getPostId())
+                .userName(reply.getUser().getUserName())
+                .parentId(reply.getParent() != null ? reply.getParent().getReplyId() : null)
+                .isRemoved(reply.isRemoved())
+                .build();
+        return DataResponseDto.of(replyResDto,"댓글이 저장되었습니다.");
+    }
+}

--- a/src/main/java/com/BitOracle/BitOracle/domain/Post.java
+++ b/src/main/java/com/BitOracle/BitOracle/domain/Post.java
@@ -39,4 +39,9 @@ public class Post extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public void addReply(Reply comment){
+        //comment의 Post 설정은 comment에서 함
+        replyList.add(comment);
+    }
 }

--- a/src/main/java/com/BitOracle/BitOracle/domain/Reply.java
+++ b/src/main/java/com/BitOracle/BitOracle/domain/Reply.java
@@ -1,7 +1,12 @@
 package com.BitOracle.BitOracle.domain;
 
+import com.BitOracle.BitOracle.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Entity
 @Getter
@@ -9,18 +14,87 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Reply {
+public class Reply extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "reply_id")
     private Long replyId;
+
     @Column(name = "reply_content")
     private String replyContent;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    private boolean isRemoved = false; //삭제 된 댓글인지 아닌지 대댓글을 위해 파악 필요
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    // 대댓글 구현을 위한 자기 참조
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Reply parent;
+
+    @OneToMany(mappedBy = "parent" , cascade = CascadeType.ALL,orphanRemoval = true)
+    private List<Reply> childList = new ArrayList<>();
+
+    //연관관계 편의 메서드
+    public void setUser(User user) {
+        this.user = user;
+        user.addReply(this);
+    }
+    public void setPost(Post post) {
+        this.post = post;
+        post.addReply(this);
+    }
+    public void setParent(Reply parent) {
+        this.parent = parent;
+        parent.addChild(this);
+    }
+    public void addChild(Reply child) {
+        childList.add(child);
+    }
+
+    // 수정 구현 x
+    public void updateContent(String content){
+        this.replyContent = content;
+    }
+    //삭제
+    public void removeReply(){
+        this.isRemoved = true; // 실제db 삭제 x boolean값만 true로
+    }
+
+    //비즈니스 로직
+    public List<Reply> findRemovableList(){
+        List<Reply> result = new ArrayList<>();
+
+        Optional.ofNullable(this.parent).ifPresentOrElse( //this parent가 null이 아니면 첫번째 람다 ifpresent, null이면 두번째 람다실행
+                parentReply ->{//대댓글인 경우 (부모가 존재하는 경우)
+                    if( parentReply.isRemoved()&& parentReply.isAllChildRemoved()){ //다 삭제 가능 부모 대댓글 싹다 삭제된 상태
+                        result.addAll(parentReply.getChildList()); //자식모두 추가
+                        result.add(parentReply); //부모 추가
+                    }
+                },
+
+                () -> {//댓글인 경우(부모가 null임)
+                    if (isAllChildRemoved()) {
+                        result.add(this); //자기자신
+                        result.addAll(this.getChildList());
+                    }
+                }
+        );
+        return result;
+    }
+    //모든 자식 댓글이 삭제되었는지 판단
+    private boolean isAllChildRemoved() {
+        return getChildList().stream()
+                .map(Reply::isRemoved)//지워졌는지 여부로 바꾼다
+                .filter(isRemove -> !isRemove)//지워졌으면 true, 안지워졌으면 false이다. 따라서 filter에 걸러지는 것은 false인 녀석들이고, 있다면 false를 없다면 orElse를 통해 true를 반환한다.
+                .findAny()//지워지지 않은게 하나라도 있다면 false를 반환
+                .orElse(true);//모두 지워졌다면 true를 반환
+    }
+
 }

--- a/src/main/java/com/BitOracle/BitOracle/domain/User.java
+++ b/src/main/java/com/BitOracle/BitOracle/domain/User.java
@@ -44,4 +44,9 @@ public class User {
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
     private Portfolio portfolio;
+
+    public void addReply(Reply reply){
+        //comment의 writer 설정은 comment에서 함
+        replyList.add(reply);
+    }
 }

--- a/src/main/java/com/BitOracle/BitOracle/dto/ReplyResDto.java
+++ b/src/main/java/com/BitOracle/BitOracle/dto/ReplyResDto.java
@@ -1,0 +1,22 @@
+package com.BitOracle.BitOracle.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+//댓글 저장 응답 dto( 대댓글아님 )
+@Getter
+@Setter
+@Builder
+public class ReplyResDto {
+    private Long replyId;
+    private String content;
+    private String userName; // 또는 userId
+    private Long postId;
+    private Long parentId;
+    private boolean isRemoved;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/BitOracle/BitOracle/dto/ReplySaveReqDto.java
+++ b/src/main/java/com/BitOracle/BitOracle/dto/ReplySaveReqDto.java
@@ -1,0 +1,24 @@
+package com.BitOracle.BitOracle.dto;
+
+import com.BitOracle.BitOracle.domain.Post;
+import com.BitOracle.BitOracle.domain.Reply;
+import com.BitOracle.BitOracle.domain.User;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class ReplySaveReqDto {
+    @NotBlank(message = "내용을 입력해주세요")
+    private String content;
+    //private Long postId;
+
+    public Reply toEntity() {
+        return Reply.builder()
+                .replyContent(this.content)
+                .build();
+    }
+}

--- a/src/main/java/com/BitOracle/BitOracle/repository/PostRepository.java
+++ b/src/main/java/com/BitOracle/BitOracle/repository/PostRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post,Long> {
     Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    Post findByPostId(Long postId);
 }

--- a/src/main/java/com/BitOracle/BitOracle/repository/ReplyRepository.java
+++ b/src/main/java/com/BitOracle/BitOracle/repository/ReplyRepository.java
@@ -1,0 +1,7 @@
+package com.BitOracle.BitOracle.repository;
+
+import com.BitOracle.BitOracle.domain.Reply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReplyRepository extends JpaRepository<Reply, Long> {
+}

--- a/src/main/java/com/BitOracle/BitOracle/repository/UserRepository.java
+++ b/src/main/java/com/BitOracle/BitOracle/repository/UserRepository.java
@@ -4,4 +4,5 @@ import com.BitOracle.BitOracle.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    User findByUserName(String userName);
 }

--- a/src/main/java/com/BitOracle/BitOracle/service/ReplyService.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/ReplyService.java
@@ -1,0 +1,55 @@
+package com.BitOracle.BitOracle.service;
+
+import com.BitOracle.BitOracle.domain.Reply;
+import com.BitOracle.BitOracle.dto.ReplySaveReqDto;
+import com.BitOracle.BitOracle.repository.PostRepository;
+import com.BitOracle.BitOracle.repository.ReplyRepository;
+import com.BitOracle.BitOracle.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+@Service
+public class ReplyService {
+    private final ReplyRepository replyRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+    public Reply saveReply(Long postId, ReplySaveReqDto replySaveReqDto){
+        Reply reply = replySaveReqDto.toEntity(); //내용
+        reply.setUser(userRepository.findByUserName("admin")); //임의 테스트 //유저저장
+        reply.setPost(postRepository.findByPostId(postId));//포스트 저장
+        return replyRepository.save(reply);
+    }
+
+    //대댓글 저장
+    public void saveRe_Reply(Long postId , Long parentId, ReplySaveReqDto replySaveReqDto){
+        Reply reply = replySaveReqDto.toEntity();
+        reply.setUser(userRepository.findByUserName("admin"));
+        reply.setPost(postRepository.findByPostId(postId));
+        reply.setParent(replyRepository.findById(parentId).get());
+        replyRepository.save(reply);
+    }
+
+/*    //지울수잇는 댓글 지우기
+    public void removeReply(Long id) throws Exception{
+        Reply reply = replyRepository.findById(id).orElseThrow(()->new Exception("해당 유저의 댓글이 없습니다"));
+        log.info(reply.toString());
+        List<Reply> removableReplyList = reply.findRemovableList();//제거 가능 댓글 배열
+        removableReplyList.forEach(removableReply -> replyRepository.delete(removableReply));//리스트 돌면서 댓글 삭제
+    }*/
+
+    public void remove(Long id){
+        Reply reply = replyRepository.findById(id).get();
+        log.info(reply.toString());
+        reply.removeReply(); // isRemoved = true;
+        List<Reply> removeableReplyList = reply.findRemovableList();
+        replyRepository.deleteAll(removeableReplyList);
+    }
+}

--- a/src/test/java/com/BitOracle/BitOracle/service/ReplyServiceTest.java
+++ b/src/test/java/com/BitOracle/BitOracle/service/ReplyServiceTest.java
@@ -1,0 +1,129 @@
+package com.BitOracle.BitOracle.service;
+
+import com.BitOracle.BitOracle.domain.Reply;
+import com.BitOracle.BitOracle.repository.ReplyRepository;
+import com.amazonaws.services.s3.AmazonS3;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test") // application-test.yml 적용
+@SpringBootTest
+@Transactional
+class ReplyServiceTest {
+
+
+    @Autowired
+    ReplyService replyService;
+    @Autowired
+    ReplyRepository replyRepository;
+    @Autowired
+    EntityManager em;
+
+    @MockBean
+    private AmazonS3 amazonS3;
+
+
+    private void clear(){
+        em.flush();
+        em.clear();
+    }
+
+    private Long saveReply() {
+        Reply reply = Reply.builder()
+                .replyContent("댓글")
+                .build();
+        Long id = replyRepository.save(reply).getReplyId();
+        clear();
+        return id;
+    }
+
+    private Long saveReComment(Long parentId){
+        Reply parent = replyRepository.findById(parentId).orElse(null);
+        Reply comment = Reply.builder().replyContent("댓글").parent(parent).build();
+
+        Long id = replyRepository.save(comment).getReplyId();
+        clear();
+        return id;
+    }
+    @Test
+    void 댓극ㄹ삭제_대댓글이_남아있는경우() {
+        //given
+        Long replyId = saveReply();
+        saveReComment(replyId);
+        saveReComment(replyId);
+        saveReComment(replyId);
+        assertThat(replyRepository.findById(replyId).get().getChildList().size()).isEqualTo(3);
+        //when
+        replyService.remove(replyId); //부모삭제
+        clear();
+        //then
+        Reply findReply = replyRepository.findById(replyId).get();
+        assertThat(findReply).isNotNull(); //부모 살아잇고
+        assertThat(findReply.isRemoved()).isTrue(); //
+        assertThat(findReply.getChildList().size()).isEqualTo(3);
+    }
+
+    // 댓글을 삭제하는 경우
+    //대댓글이 아예 존재하지 않는 경우 : 곧바로 DB에서 삭제
+    @Test
+    public void 댓글삭제_대댓글이_없는_경우() {
+        //given
+        Long commentId = saveReply();
+
+        //when
+        replyService.remove(commentId);
+        clear();
+
+        //then
+        Assertions.assertThat(replyRepository.findAll().size()).isSameAs(0);
+        //assertThat( assertThrows(Exception.class, () -> replyRepository.findById(commentId)).getMessage()).isEqualTo("댓글이 없습니다.");
+    }
+    
+    //댓글 삭제
+    //대댓글 존재 but 모두 삭제 됨
+    //댓글과, 달려잇는 대댓글 모두 db 일괄 삭제, 화면상도 ㄴㄴ
+    @Test
+    public void 댓글삭제_대댓글존재_but_모두삭제된_대댓글(){
+        Long replyId = saveReply();
+        Long reComment1Id = saveReComment(replyId);
+        Long reComment2Id = saveReComment(replyId);
+        Long reComment3Id = saveReComment(replyId);
+        Long reComment4Id = saveReComment(replyId);
+
+        assertThat(replyRepository.findById(replyId).get().getChildList().size()).isEqualTo(4);
+        clear();
+        replyService.remove(reComment1Id);
+        clear();
+        replyService.remove(reComment2Id);
+        clear();
+        replyService.remove(reComment3Id);
+        clear();
+        replyService.remove(reComment4Id);
+        clear();
+        assertThat(replyRepository.findById(reComment1Id).get().isRemoved()).isTrue();
+        assertThat(replyRepository.findById(reComment2Id).get().isRemoved()).isTrue();
+        assertThat(replyRepository.findById(reComment3Id).get().isRemoved()).isTrue();
+        assertThat(replyRepository.findById(reComment4Id).get().isRemoved()).isTrue();
+
+        //wwhem 댓글 지워쓸때
+        replyService.remove(replyId);
+        clear();
+        //tjem
+        assertThat(replyRepository.findById(replyId)).isEmpty();
+        assertThat(replyRepository.findById(reComment1Id)).isEmpty();
+        assertThat(replyRepository.findById(reComment2Id)).isEmpty();
+        assertThat(replyRepository.findById(reComment3Id)).isEmpty();
+        assertThat(replyRepository.findById(reComment4Id)).isEmpty();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password : ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop # 테스트니까 create-drop 추천 (매 테스트마다 테이블 생성/삭제)
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  # 테스트 DB라면 이런 옵션도 있어
+  sql:
+    init:
+      mode: always


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #

## 📝작업 내용

>댓글을 삭제하는 경우

삭제하는 댓글이 댓글인 경우(부모)

**대댓글이 남아있는 경우 : 댓글은 내용이 지워지나, DB에와 화면에서는 지워지지 않고, "삭제된 댓글입니다"라고 표시
대댓글이 아예 존재하지 않는 경우 : 곧바로 DB에서 삭제
대댓글이 존재하나 모두 삭제된 대댓글인 경우 : 댓글과, 달려있는 대댓글 모두 DB에서 일괄 삭제, 화면상에도 표시되지 않음


삭제하는 댓글이 대댓글인 경우(자식)

대댓글의 부모댓글이 남아있는 경우 : 대댓글만 삭제, 그러나 DB에서 완전히 지워지지는 않고, 화면상에는 "삭제된 댓글입니다" 라고만 표시
대댓글의 부모댓글이 삭제된 댓글인 경우 

현재 지운 대댓글로 인해, 부모에 달려있는 대댓글이 모두 삭제된 경우 -> 부모를 포함한 모든 대댓글을 DB에서 일괄 삭제, 화면상에서도 지움
다른 대댓글이 아직 삭제되지 않고 남아있는 경우 -> 해당 대댓글만 삭제, 그러나 DB에서 삭제되지는 않고, 화면상에는 "삭제된 댓글입니다"라고 표시**
출처: https://ttl-blog.tistory.com/278 [Shin._.Mallang:티스토리]

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?