### PR TITLE
feat: 호재/악재 뉴스 전체 조회 API 구현

### DIFF
--- a/src/main/java/com/BitOracle/BitOracle/config/SecurityConfig.java
+++ b/src/main/java/com/BitOracle/BitOracle/config/SecurityConfig.java
@@ -95,7 +95,7 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",                       // Swagger 문서 JSON
                                 "/swagger-ui/**", "/swagger-ui.html",    // Swagger UI
                                 "/swagger-resources/**", "/webjars/**",   // Swagger 리소스
-                                "/api/predict/midnight", "/api/test/**", "api/news/main",         // 로그인 상관 없이 허용되는 api
+                                "/api/predict/midnight", "/api/test/**", "api/news/**",         // 로그인 상관 없이 허용되는 api
                                 "/api/community/**",
                                 "/ws-upbit/**",
                                 "/api/reply/**"

--- a/src/main/java/com/BitOracle/BitOracle/controller/NewsController.java
+++ b/src/main/java/com/BitOracle/BitOracle/controller/NewsController.java
@@ -22,4 +22,16 @@ public class NewsController {
         List<NewsResponseDto.MainNewsResponseDto> responseDto = newsService.getMainNews();
         return DataResponseDto.of(responseDto, "오늘의 뉴스 6개를 조회했습니다.");
     }
+
+    @GetMapping(value = "/news/goodNews")
+    public DataResponseDto<List<NewsResponseDto.GoodBadNewsResponseDto>> getGoodNews(){
+        List<NewsResponseDto.GoodBadNewsResponseDto> responseDto = newsService.getGoodNews();
+        return DataResponseDto.of(responseDto, "호재 뉴스를 모두 조회했습니다.");
+    }
+
+    @GetMapping(value = "/news/badNews")
+    public DataResponseDto<List<NewsResponseDto.GoodBadNewsResponseDto>> getBadNews(){
+        List<NewsResponseDto.GoodBadNewsResponseDto> responseDto = newsService.getBadNews();
+        return DataResponseDto.of(responseDto, "악재 뉴스를 모두 조회했습니다.");
+    }
 }

--- a/src/main/java/com/BitOracle/BitOracle/converter/NewsConverter.java
+++ b/src/main/java/com/BitOracle/BitOracle/converter/NewsConverter.java
@@ -1,0 +1,37 @@
+package com.BitOracle.BitOracle.converter;
+
+import com.BitOracle.BitOracle.domain.News;
+import com.BitOracle.BitOracle.dto.NewsResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class NewsConverter {
+
+    public List<NewsResponseDto.MainNewsResponseDto> toMainNewsResponseDto(List<News> newsList) {
+        return newsList.stream()
+                .map(news -> NewsResponseDto.MainNewsResponseDto.builder()
+                        .newsTitle(news.getNewsTitle())
+                        .newsContent(news.getNewsContent().substring(0, 50) + "...")
+                        .imageUrl(news.getImageUrl())
+                        .newsType(news.getNewsType())
+                        .build()
+                )
+                .collect(Collectors.toList());
+    }
+
+    public List<NewsResponseDto.GoodBadNewsResponseDto> toGoodBadNewsResponseDtoList(List<News> newsList) {
+        return newsList.stream()
+                .map(news -> NewsResponseDto.GoodBadNewsResponseDto.builder()
+                        .newsTitle(news.getNewsTitle())
+                        .newsContent(news.getNewsContent()) // 불필요시 제외
+                        .newsUrl(news.getNewsUrl())
+                        .build()
+                )
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/BitOracle/BitOracle/dto/NewsResponseDto.java
+++ b/src/main/java/com/BitOracle/BitOracle/dto/NewsResponseDto.java
@@ -23,4 +23,17 @@ public class NewsResponseDto {
         @JsonProperty("news_type")
         private NewsType newsType;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GoodBadNewsResponseDto {
+        @JsonProperty("news_title")
+        private String newsTitle;
+        @JsonProperty("news_content")
+        private String newsContent;
+        @JsonProperty("news_url")
+        private String newsUrl;
+    }
 }

--- a/src/main/java/com/BitOracle/BitOracle/repository/NewsRepository.java
+++ b/src/main/java/com/BitOracle/BitOracle/repository/NewsRepository.java
@@ -1,6 +1,7 @@
 package com.BitOracle.BitOracle.repository;
 
 import com.BitOracle.BitOracle.domain.News;
+import com.BitOracle.BitOracle.domain.enums.NewsType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,4 +9,5 @@ import java.util.List;
 public interface NewsRepository extends JpaRepository<News, Long> {
     boolean existsByNewsUrl(String newsUrl);
     List<News> findTop6ByOrderByCreatedAtDesc();
+    List<News> findByNewsType(NewsType newsType);
 }

--- a/src/main/java/com/BitOracle/BitOracle/service/NewsService.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/NewsService.java
@@ -1,5 +1,8 @@
 package com.BitOracle.BitOracle.service;
 
+import com.BitOracle.BitOracle.converter.NewsConverter;
+import com.BitOracle.BitOracle.domain.News;
+import com.BitOracle.BitOracle.domain.enums.NewsType;
 import com.BitOracle.BitOracle.dto.NewsResponseDto;
 import com.BitOracle.BitOracle.repository.NewsRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,15 +15,20 @@ import java.util.List;
 public class NewsService {
 
     private final NewsRepository newsRepository;
+    private final NewsConverter newsConverter;
 
     public List<NewsResponseDto.MainNewsResponseDto> getMainNews(){
-        return newsRepository.findTop6ByOrderByCreatedAtDesc().stream()
-                .map(news -> new NewsResponseDto.MainNewsResponseDto(
-                        news.getNewsTitle(),
-                        news.getNewsContent().substring(0, 50) + "...", // 지금은 50자만 응답하는걸로. 화면 나오는거 보고 조절
-                        news.getImageUrl(),
-                        news.getNewsType()
-                ))
-                .toList();
+        List<News> mainNewsList = newsRepository.findTop6ByOrderByCreatedAtDesc();
+        return newsConverter.toMainNewsResponseDto(mainNewsList);
+    }
+
+    public List<NewsResponseDto.GoodBadNewsResponseDto> getGoodNews() {
+        List<News> goodNewsList = newsRepository.findByNewsType(NewsType.GOOD);
+        return newsConverter.toGoodBadNewsResponseDtoList(goodNewsList);
+    }
+
+    public List<NewsResponseDto.GoodBadNewsResponseDto> getBadNews() {
+        List<News> badNewsList = newsRepository.findByNewsType(NewsType.BAD);
+        return newsConverter.toGoodBadNewsResponseDtoList(badNewsList);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #32 

## 📝작업 내용

> 호재/악재 뉴스 전체 조회 API 구현
> 메인페이지 카드 뉴스 API의 service 코드 converter에서 처리하도록 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?