### PR TITLE
fix: User 엔티티와 UserEntity 엔티티 연결

### DIFF
--- a/src/main/java/com/BitOracle/BitOracle/controller/PostController.java
+++ b/src/main/java/com/BitOracle/BitOracle/controller/PostController.java
@@ -2,6 +2,7 @@ package com.BitOracle.BitOracle.controller;
 
 import com.BitOracle.BitOracle.domain.User;
 import com.BitOracle.BitOracle.domain.UserEntity;
+import com.BitOracle.BitOracle.domain.enums.UserType;
 import com.BitOracle.BitOracle.dto.*;
 import com.BitOracle.BitOracle.repository.UserRepository;
 import com.BitOracle.BitOracle.response.DataResponseDto;
@@ -34,7 +35,8 @@ public class PostController {
                                                     )
     {
         User user = User.builder()
-                .userName("진서")
+                .nickname("jinseo")
+                .userType(UserType.USER)
                 .point(1)
                 .build();
         userRepository.save(user);

--- a/src/main/java/com/BitOracle/BitOracle/controller/Replycontroller.java
+++ b/src/main/java/com/BitOracle/BitOracle/controller/Replycontroller.java
@@ -25,7 +25,7 @@ public class Replycontroller {
                 .createdAt(reply.getCreatedAt())
                 .content(reply.getReplyContent())
                 .postId(reply.getPost().getPostId())
-                .userName(reply.getUser().getUserName())
+                .userName(reply.getUser().getNickname())
                 .parentId(reply.getParent() != null ? reply.getParent().getReplyId() : null)
                 .isRemoved(reply.isRemoved())
                 .build();

--- a/src/main/java/com/BitOracle/BitOracle/domain/Prediction.java
+++ b/src/main/java/com/BitOracle/BitOracle/domain/Prediction.java
@@ -20,9 +20,6 @@ public class Prediction extends BaseEntity {
     @Column(name = "predict_id")
     private Long predictId;
 
-    @Column(name = "predict_time")
-    private Date predictTime;
-
     @Column(name = "is_correct")
     private Boolean isCorrect;
 

--- a/src/main/java/com/BitOracle/BitOracle/domain/User.java
+++ b/src/main/java/com/BitOracle/BitOracle/domain/User.java
@@ -1,6 +1,7 @@
 package com.BitOracle.BitOracle.domain;
 
 import com.BitOracle.BitOracle.common.BaseEntity;
+import com.BitOracle.BitOracle.domain.enums.UserType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,17 +19,16 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long userId;
-    @Column(nullable = false, name = "user_name")
-    private String userName;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(name = "user_type")
+    @Enumerated(EnumType.STRING)
+    private UserType userType;
 
     @Column(nullable = false, name = "point")
     private Integer point;
-//    @Column(nullable = false, name = "user_email")
-//    private String userEmail;
-//    @Column(nullable = false, name = "google_id")
-//    private String googleId;
-//    @Column(nullable = false, name = "img_url")
-//    private String imgUrl;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Reply> replyList = new ArrayList<>();

--- a/src/main/java/com/BitOracle/BitOracle/domain/UserEntity.java
+++ b/src/main/java/com/BitOracle/BitOracle/domain/UserEntity.java
@@ -1,10 +1,7 @@
 package com.BitOracle.BitOracle.domain;
 
 import com.BitOracle.BitOracle.common.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -20,4 +17,10 @@ public class UserEntity extends BaseEntity {
     private String name;
     private String email;
     private String role;
+
+    // UserEntity는 로그인 정보만 관리, User는 다른 테이블들과 관계를 가지도록 구분하기 위해
+    // UserEntity가 User를 참조하도록 설계
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
 }

--- a/src/main/java/com/BitOracle/BitOracle/domain/enums/UserType.java
+++ b/src/main/java/com/BitOracle/BitOracle/domain/enums/UserType.java
@@ -1,0 +1,12 @@
+package com.BitOracle.BitOracle.domain.enums;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum UserType {
+
+    USER("일반유저"),
+    EXPERT("전문가");
+
+    private final String newType;
+}

--- a/src/main/java/com/BitOracle/BitOracle/repository/UserRepository.java
+++ b/src/main/java/com/BitOracle/BitOracle/repository/UserRepository.java
@@ -4,5 +4,5 @@ import com.BitOracle.BitOracle.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    User findByUserName(String userName);
+    User findByNickname(String nickname);
 }

--- a/src/main/java/com/BitOracle/BitOracle/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/CustomOAuth2UserService.java
@@ -1,8 +1,11 @@
 package com.BitOracle.BitOracle.service;
 
+import com.BitOracle.BitOracle.domain.User;
 import com.BitOracle.BitOracle.domain.UserEntity;
+import com.BitOracle.BitOracle.domain.enums.UserType;
 import com.BitOracle.BitOracle.dto.*;
 import com.BitOracle.BitOracle.repository.UserEntityRepository;
+import com.BitOracle.BitOracle.repository.UserRepository;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -13,9 +16,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-    private final UserEntityRepository userRepository;
+    private final UserEntityRepository userEntityRepository;
+    private final UserRepository userRepository;
 
-    public CustomOAuth2UserService(UserEntityRepository userRepository){
+    public CustomOAuth2UserService(UserEntityRepository userEntityRepository, UserRepository userRepository){
+        this.userEntityRepository = userEntityRepository;
         this.userRepository = userRepository;
     }
 
@@ -37,11 +42,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             return null;
         }
 
-        // 로그인 완료 시 로직은 추후 작성
-
         // 네이버와 구글에서 온 유저 이름을 우리는 구분해서 관리해줘야 하기 때문에
         String username = oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
-        UserEntity existData = userRepository.findByUsername(username);
+        UserEntity existData = userEntityRepository.findByUsername(username);
 
         if (existData == null){
             UserEntity userEntity = new UserEntity();
@@ -50,7 +53,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             userEntity.setName(oAuth2Response.getName());
             userEntity.setRole("ROLE_USER");
 
-            userRepository.save(userEntity);
+            User user = User.builder()
+                    .nickname(oAuth2Response.getEmail().substring(0, oAuth2Response.getEmail().indexOf("@")))
+                    .point(0)
+                    .userType(UserType.USER)
+                    .build();
+
+            userRepository.save(user);
+
+            userEntity.setUser(user);
+            userEntityRepository.save(userEntity);
 
             UserDTO userDTO = new UserDTO();
             userDTO.setUsername(username);
@@ -64,7 +76,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             existData.setEmail(oAuth2Response.getEmail());
             existData.setName(oAuth2Response.getName());
 
-            userRepository.save(existData);
+            userEntityRepository.save(existData);
+
+            User existUser = existData.getUser();
+            existUser.setNickname(oAuth2Response.getEmail().substring(0, oAuth2Response.getEmail().indexOf("@")));
+
+            userRepository.save(existUser);
 
             UserDTO userDTO = new UserDTO();
             userDTO.setUsername(existData.getUsername());

--- a/src/main/java/com/BitOracle/BitOracle/service/PostService.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/PostService.java
@@ -70,7 +70,7 @@ public class PostService {
                 .id(saved.getPostId())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .authorName(user.getUserName())
+                .authorName(user.getNickname())
                 .build();
     }
 
@@ -122,7 +122,7 @@ public class PostService {
                         .id(post.getPostId())
                         .title(post.getTitle())
                         .content(post.getContent())
-                        .writer(post.getUser().getUserName()) // 작성자 이름
+                        .writer(post.getUser().getNickname()) // 작성자 이름
                         .createdAt(post.getCreatedAt())
                         .build());
     }

--- a/src/main/java/com/BitOracle/BitOracle/service/ReplyService.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/ReplyService.java
@@ -23,7 +23,7 @@ public class ReplyService {
 
     public Reply saveReply(Long postId, ReplySaveReqDto replySaveReqDto){
         Reply reply = replySaveReqDto.toEntity(); //내용
-        reply.setUser(userRepository.findByUserName("admin")); //임의 테스트 //유저저장
+        reply.setUser(userRepository.findByNickname("admin")); //임의 테스트 //유저저장
         reply.setPost(postRepository.findByPostId(postId));//포스트 저장
         return replyRepository.save(reply);
     }
@@ -31,7 +31,7 @@ public class ReplyService {
     //대댓글 저장
     public void saveRe_Reply(Long postId , Long parentId, ReplySaveReqDto replySaveReqDto){
         Reply reply = replySaveReqDto.toEntity();
-        reply.setUser(userRepository.findByUserName("admin"));
+        reply.setUser(userRepository.findByNickname("admin"));
         reply.setPost(postRepository.findByPostId(postId));
         reply.setParent(replyRepository.findById(parentId).get());
         replyRepository.save(reply);


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #36 

## 📝작업 내용

> UserEntity와 User를 통합시키는 대신 1:1 의존관계를 통해 연결
> UserEntitiy에서는 로그인 관련 데이터, User에서는 나머지 데이터 처리
> UserEntity 생성이나 변경시에 User도 자동으로 생성, 변경되도록 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?