### PR TITLE
feat: 사용자 예측을 위한 스케줄링 구현

### DIFF
--- a/src/main/java/com/BitOracle/BitOracle/controller/TestController.java
+++ b/src/main/java/com/BitOracle/BitOracle/controller/TestController.java
@@ -2,6 +2,7 @@ package com.BitOracle.BitOracle.controller;
 
 import com.BitOracle.BitOracle.jwt.JWTUtil;
 import com.BitOracle.BitOracle.response.DataResponseDto;
+import com.BitOracle.BitOracle.service.BtcPriceService;
 import com.BitOracle.BitOracle.service.RunNewsPipeline;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ public class TestController {
 
     private final RunNewsPipeline runNewsPipeline;
     private final JWTUtil jwtUtil;
+    private final BtcPriceService btcPriceService;
 
     @GetMapping("/auth/test")
     public String testLogin() {
@@ -39,4 +41,23 @@ public class TestController {
 
         return ResponseEntity.ok(accessToken);
     }
+
+    @GetMapping("/run-save-midnightPrice")
+    public String runSaveMidnightPriceNow() throws InterruptedException {
+        btcPriceService.saveMidnightBtcPrice();
+        return "00시 기준가 저장 완료!";
+    }
+
+    @GetMapping("/run-updateIsCorrect")
+    public String runUpdateIsCorrectNow() throws InterruptedException {
+        btcPriceService.updateIsCorrect();
+        return "Prediction의 isCorrect 속성 업데이트 완료!";
+    }
+
+    @GetMapping("/run-updateUserRecords")
+    public String runUpdateUserRecords() throws InterruptedException {
+        btcPriceService.updateUserRecords();
+        return "유저 통계 테이블 업데이트 완료!";
+    }
+
 }

--- a/src/main/java/com/BitOracle/BitOracle/repository/PredictionRepository.java
+++ b/src/main/java/com/BitOracle/BitOracle/repository/PredictionRepository.java
@@ -3,5 +3,9 @@ package com.BitOracle.BitOracle.repository;
 import com.BitOracle.BitOracle.domain.Prediction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface PredictionRepository extends JpaRepository<Prediction, Long> {
+    List<Prediction> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/BitOracle/BitOracle/repository/RecordRepository.java
+++ b/src/main/java/com/BitOracle/BitOracle/repository/RecordRepository.java
@@ -1,0 +1,9 @@
+package com.BitOracle.BitOracle.repository;
+
+import com.BitOracle.BitOracle.domain.Record;
+import com.BitOracle.BitOracle.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecordRepository extends JpaRepository<Record, Long> {
+    Record findByUser(User user);
+}

--- a/src/main/java/com/BitOracle/BitOracle/service/BtcPriceService.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/BtcPriceService.java
@@ -1,41 +1,56 @@
 package com.BitOracle.BitOracle.service;
 
 import com.BitOracle.BitOracle.domain.BtcPrice;
+import com.BitOracle.BitOracle.domain.Prediction;
+import com.BitOracle.BitOracle.domain.Record;
+import com.BitOracle.BitOracle.domain.User;
+import com.BitOracle.BitOracle.domain.enums.PredictType;
 import com.BitOracle.BitOracle.repository.BtcPriceRepository;
+import com.BitOracle.BitOracle.repository.PredictionRepository;
+import com.BitOracle.BitOracle.repository.RecordRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 @Slf4j
 public class BtcPriceService {
     private final BtcPriceRepository btcPriceRepository;
+    private final PredictionRepository predictionRepository;
+    private final RecordRepository recordRepository;
 
     public BtcPrice getMidnightBtc(){
         LocalDate today = LocalDate.now();
         log.info("Today is {}", today);
 
-        // 1. DB에 이미 있다면 DB에서 가져옴
+        // 스케줄링되어 db에 저장된 00시 기준 가격을 가져옴
         BtcPrice btcPrice = btcPriceRepository.findByCoinDate(today);
-        if (btcPrice != null) {
-            log.info("Found price in DB: {}", btcPrice.getPrice());
-            return btcPrice;
-        }
+        log.info("Found price in DB: {}", btcPrice.getPrice());
+        return btcPrice;
+    }
+
+    @Scheduled(cron = "1 0 0 * * *", zone = "Asia/Seoul") // 00시 0분 1초에 스케줄링
+    public void saveMidnightBtcPrice() {
+        LocalDate today = LocalDate.now();
 
         try {
-            // 2. 업비트 API 호출 (금일 00시 기준 가격)
+            // 1. 오늘 00시 기준 업비트 BTC 가격 저장
             ZonedDateTime todayMidnightKst = today.atStartOfDay(ZoneId.of("Asia/Seoul"));
             String toDate = todayMidnightKst.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")); // RFC3339
 
@@ -60,10 +75,98 @@ public class BtcPriceService {
             btcPriceRepository.save(newPrice);
             log.info("Saved new BTC Date: {}, price: {}", today, openingPrice);
 
-            return newPrice;
+            // 2. 어제/오늘 가격 비교해서 Prediction isCorrect 업데이트
+            updateIsCorrect();
+            log.info("Prediction 정답 업데이트 완료");
+
+            // 3. 모든 User Record 갱신
+            updateUserRecords();
+            log.info("User Record 재계산 및 업데이트 완료");
+
         } catch (Exception e) {
             log.error("Error while calling Upbit API", e);
             throw new RuntimeException("업비트 API 호출 실패", e);
         }
     }
+
+    @Transactional
+    public void updateIsCorrect() {
+        LocalDate today = LocalDate.now();
+        LocalDate yesterday = today.minusDays(1);
+
+        // 오늘 가격과 어제 가격 가져오기
+        BtcPrice todayPriceEntity = btcPriceRepository.findByCoinDate(today);
+        BtcPrice yesterdayPriceEntity = btcPriceRepository.findByCoinDate(yesterday);
+
+        if (todayPriceEntity == null || yesterdayPriceEntity == null) {
+            log.error("오늘 또는 어제 가격 데이터가 없습니다.");
+            throw new RuntimeException("가격 데이터가 부족합니다.");
+        }
+
+        BigDecimal todayPrice = todayPriceEntity.getPrice();
+        BigDecimal yesterdayPrice = yesterdayPriceEntity.getPrice();
+
+        // 가격 비교해서 방향 결정
+        PredictType realUpDown = todayPrice.compareTo(yesterdayPrice) > 0 ? PredictType.UP : PredictType.DOWN;
+
+        log.info("어제 가격: {}, 오늘 가격: {}, 실제 방향: {}", yesterdayPrice, todayPrice, realUpDown);
+
+        // 오늘 날짜의 Prediction 가져와서 isCorrect 업데이트
+        List<Prediction> predictions = predictionRepository.findByCreatedAtBetween(today.atStartOfDay(), today.atTime(23, 59, 59));
+
+        for (Prediction prediction : predictions) {
+            if (prediction.getUpDown() == realUpDown) {
+                prediction.setIsCorrect(true);
+            } else {
+                prediction.setIsCorrect(false);
+            }
+        }
+
+        predictionRepository.saveAll(predictions);
+        log.info("모든 prediction isCorrect 업데이트 완료");
+    }
+
+    @Transactional
+    public void updateUserRecords() {
+        // 모든 유저들의 Record를 업데이트
+
+        // 전체 Prediction 가져오기
+        List<Prediction> allPredictions = predictionRepository.findAll();
+
+        // User별로 Prediction을 그룹핑
+        Map<User, List<Prediction>> predictionsByUser = allPredictions.stream()
+                .collect(Collectors.groupingBy(Prediction::getUser));
+
+        for (Map.Entry<User, List<Prediction>> entry : predictionsByUser.entrySet()) {
+            User user = entry.getKey();
+            List<Prediction> userPredictions = entry.getValue();
+
+            int totalTrial = userPredictions.size();
+            int totalSuccess = (int) userPredictions.stream().filter(Prediction::getIsCorrect).count();
+            int totalFailure = totalTrial - totalSuccess;
+
+            // User의 Record 가져오기
+            Record record = recordRepository.findByUser(user);
+
+            if (record == null) {
+                // Record 없으면 새로 생성
+                record = Record.builder()
+                        .user(user)
+                        .trial(totalTrial)
+                        .success(totalSuccess)
+                        .failure(totalFailure)
+                        .build();
+            } else {
+                // Record 있으면 값 갱신
+                record.setTrial(totalTrial);
+                record.setSuccess(totalSuccess);
+                record.setFailure(totalFailure);
+            }
+
+            recordRepository.save(record);
+        }
+
+        log.info("전체 유저 Record 재계산 및 업데이트 완료");
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #46 

## 📝작업 내용

> saveMidnightBtcPrice() => 매일 00시 0분 1초에 업비트에서 00시 기준 가격을 가져오고 updateIsCorrect()과
> updateUserRecords() 호출
> updateIsCorrect() => 어제와 오늘의 기준 가격을 비교해 Prediction 테이블의 모든 객체의 isCorrect 속성 업데이트
> updateUserRecords() => 해당 유저의 Prediction 테이블 행의 갯수와 isCorrect 갯수로 계산하여 각 사용자의 통계 업데이트

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?