### PR TITLE
feat: 달력 히스토리 조회 API, 예측 통계 조회 API 구현

### DIFF
--- a/src/main/java/com/BitOracle/BitOracle/controller/PredictionController.java
+++ b/src/main/java/com/BitOracle/BitOracle/controller/PredictionController.java
@@ -2,6 +2,7 @@ package com.BitOracle.BitOracle.controller;
 
 import com.BitOracle.BitOracle.converter.PredictionConverter;
 import com.BitOracle.BitOracle.domain.Prediction;
+import com.BitOracle.BitOracle.domain.Record;
 import com.BitOracle.BitOracle.dto.PredictionRequestDto;
 import com.BitOracle.BitOracle.dto.PredictionResponseDto;
 import com.BitOracle.BitOracle.response.DataResponseDto;
@@ -10,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -27,5 +30,25 @@ public class PredictionController {
         PredictionResponseDto.selectUpDownResponseDto responseDto = PredictionConverter.toSelectUpDownResponseDto(prediction);
 
         return DataResponseDto.of(responseDto, "UP/DOWN 예측 정보를 저장했습니다.");
+    }
+
+    @GetMapping(value = "predict/calender")
+    public DataResponseDto<List<PredictionResponseDto.getCalenderResponseDto>> getCalender(
+            @CookieValue("access") String authorization){
+
+        List<Prediction> predictionList = predictionService.getCalender(authorization);
+        List<PredictionResponseDto.getCalenderResponseDto> responseDto = PredictionConverter.toGetCalenderResponseDto(predictionList);
+
+        return DataResponseDto.of(responseDto, "해당 유저의 달력 히스토리 조회를 위한 모든 예측 기록을 조회했습니다.");
+    }
+
+    @GetMapping(value = "predict/stats")
+    public DataResponseDto<PredictionResponseDto.getStatsResponseDto> getStats(
+            @CookieValue("access") String authorization){
+
+        Record record = predictionService.getStats(authorization);
+        PredictionResponseDto.getStatsResponseDto responseDto = PredictionConverter.toGetStatsResponseDto(record);
+
+        return DataResponseDto.of(responseDto, "해당 유저의 예측 통계 정보를 조회했습니다.");
     }
 }

--- a/src/main/java/com/BitOracle/BitOracle/converter/PredictionConverter.java
+++ b/src/main/java/com/BitOracle/BitOracle/converter/PredictionConverter.java
@@ -1,9 +1,15 @@
 package com.BitOracle.BitOracle.converter;
 
 import com.BitOracle.BitOracle.domain.Prediction;
+import com.BitOracle.BitOracle.domain.Record;
+import com.BitOracle.BitOracle.dto.NewsResponseDto;
 import com.BitOracle.BitOracle.dto.PredictionResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -13,6 +19,27 @@ public class PredictionConverter {
         return PredictionResponseDto.selectUpDownResponseDto.builder()
                 .predictId(prediction.getPredictId())
                 .upDown(prediction.getUpDown())
+                .build();
+    }
+
+    public static List<PredictionResponseDto.getCalenderResponseDto> toGetCalenderResponseDto(List<Prediction> predictionList){
+        return predictionList.stream()
+                .map(prediction -> PredictionResponseDto.getCalenderResponseDto.builder()
+                        .predictId(prediction.getPredictId())
+                        .createdAt(LocalDate.from(prediction.getCreatedAt()))
+                        .upDown(prediction.getUpDown())
+                        .correct(prediction.getIsCorrect())
+                        .build()
+                )
+                .collect(Collectors.toList());
+    }
+
+    public static PredictionResponseDto.getStatsResponseDto toGetStatsResponseDto(Record record){
+        return PredictionResponseDto.getStatsResponseDto.builder()
+                .recordId(record.getRecordId())
+                .trial(record.getTrial())
+                .success(record.getSuccess())
+                .failure(record.getFailure())
                 .build();
     }
 }

--- a/src/main/java/com/BitOracle/BitOracle/dto/PredictionResponseDto.java
+++ b/src/main/java/com/BitOracle/BitOracle/dto/PredictionResponseDto.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 public class PredictionResponseDto {
 
     @Builder
@@ -20,5 +22,38 @@ public class PredictionResponseDto {
 
         @JsonProperty("up_down")
         private PredictType upDown;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getCalenderResponseDto{
+        @JsonProperty("predict_id")
+        private Long predictId;
+
+        @JsonProperty("created_at")
+        private LocalDate createdAt;
+
+        @JsonProperty("up_down")
+        private PredictType upDown;
+
+        @JsonProperty("correct")
+        private boolean correct;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getStatsResponseDto{
+        @JsonProperty("record_id")
+        private Long recordId;
+
+        private int trial;
+
+        private int success;
+
+        private int failure;
     }
 }

--- a/src/main/java/com/BitOracle/BitOracle/repository/PredictionRepository.java
+++ b/src/main/java/com/BitOracle/BitOracle/repository/PredictionRepository.java
@@ -1,6 +1,7 @@
 package com.BitOracle.BitOracle.repository;
 
 import com.BitOracle.BitOracle.domain.Prediction;
+import com.BitOracle.BitOracle.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -8,4 +9,5 @@ import java.util.List;
 
 public interface PredictionRepository extends JpaRepository<Prediction, Long> {
     List<Prediction> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+    List<Prediction> findByUser(User user);
 }

--- a/src/main/java/com/BitOracle/BitOracle/service/PredictionService.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/PredictionService.java
@@ -1,17 +1,21 @@
 package com.BitOracle.BitOracle.service;
 
 import com.BitOracle.BitOracle.domain.Prediction;
+import com.BitOracle.BitOracle.domain.Record;
 import com.BitOracle.BitOracle.domain.User;
 import com.BitOracle.BitOracle.domain.UserEntity;
 import com.BitOracle.BitOracle.dto.PredictionRequestDto;
 import com.BitOracle.BitOracle.jwt.JWTUtil;
 import com.BitOracle.BitOracle.repository.PredictionRepository;
+import com.BitOracle.BitOracle.repository.RecordRepository;
 import com.BitOracle.BitOracle.repository.UserEntityRepository;
 import com.BitOracle.BitOracle.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ public class PredictionService {
     private final JWTUtil jwtUtil;
     private final UserEntityRepository userEntityRepository;
     private final UserRepository userRepository;
+    private final RecordRepository recordRepository;
 
     public Prediction selectUpDown(String authorization, PredictionRequestDto.PredictionUpDownRequestDto predictionUpDownRequestDto){
         Long userId = getUserId(authorization);
@@ -34,6 +39,24 @@ public class PredictionService {
                 .build();
 
         return predictionRepository.save(prediction);
+    }
+
+    public List<Prediction> getCalender(String authorization){
+        Long userId = getUserId(authorization);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+        log.info(user.toString());
+
+        return predictionRepository.findByUser(user);
+    }
+
+    public Record getStats(String authorization){
+        Long userId = getUserId(authorization);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+        log.info(user.toString());
+
+        return recordRepository.findByUser(user);
     }
 
     public Long getUserId(String authorization){


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #52 

## 📝작업 내용

> 사용자 예측을 위한 스케줄링에서 db에 저장된 정보들을 조회하는 API 2개 구현
달력 히스토리 조회 API는 로그인된 사용자의 모든 예측 객체를 response해 달력에 해당 날짜의 예측 UP/DOWN 선택 정보와 적중/실패 정보를 조회해 화면에 띄울 수 있도록 함
예측 통계 조회 API는 마찬가지로 스케줄링을 통해 예측 객체를 보고 계산된 해당 유저의 예측 시도 횟수, 성공 횟수, 실패 횟수를 조회해 화면에 띄울 수 있도록 함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?