### PR TITLE
feat: 지표 정보 조회 API 및 웹 소켓 구현

### DIFF
--- a/src/main/java/com/BitOracle/BitOracle/config/SecurityConfig.java
+++ b/src/main/java/com/BitOracle/BitOracle/config/SecurityConfig.java
@@ -96,7 +96,7 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",                       // Swagger 문서 JSON
                                 "/swagger-ui/**", "/swagger-ui.html",    // Swagger UI
                                 "/swagger-resources/**", "/webjars/**",   // Swagger 리소스
-                                "/api/predict/midnight", "/api/test/**", "api/news/**",         // 로그인 상관 없이 허용되는 api
+                                "/api/predict/midnight", "/api/test/**", "api/news/**", "api/metrics",         // 로그인 상관 없이 허용되는 api
                                 "/api/community/**",
                                 "api/community/post","api/community/**",
                                 "/ws-upbit/**", // SockJS endpoint

--- a/src/main/java/com/BitOracle/BitOracle/controller/MetricsController.java
+++ b/src/main/java/com/BitOracle/BitOracle/controller/MetricsController.java
@@ -1,0 +1,22 @@
+package com.BitOracle.BitOracle.controller;
+
+import com.BitOracle.BitOracle.dto.MetricsDto;
+import com.BitOracle.BitOracle.websocket.MetricsCache;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MetricsController {
+
+    private final MetricsCache metricsCache;
+
+    @GetMapping("/metrics")
+    public MetricsDto getCachedMetrics() {
+        return metricsCache.get();
+    }
+}
+

--- a/src/main/java/com/BitOracle/BitOracle/dto/CoinMarketCapResponse.java
+++ b/src/main/java/com/BitOracle/BitOracle/dto/CoinMarketCapResponse.java
@@ -1,0 +1,20 @@
+package com.BitOracle.BitOracle.dto;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class CoinMarketCapResponse {
+    private Map<String, CryptoData> data;
+
+    @Getter
+    public static class CryptoData {
+        private Map<String, Quote> quote;
+    }
+
+    @Getter
+    public static class Quote {
+        private String price;
+    }
+}

--- a/src/main/java/com/BitOracle/BitOracle/dto/MetricsDto.java
+++ b/src/main/java/com/BitOracle/BitOracle/dto/MetricsDto.java
@@ -1,0 +1,18 @@
+package com.BitOracle.BitOracle.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class MetricsDto {
+    private BigDecimal marketCap;
+    private BigDecimal btcDominance;
+    private BigDecimal kimchiPremium;
+}

--- a/src/main/java/com/BitOracle/BitOracle/dto/UpbitTickerResponse.java
+++ b/src/main/java/com/BitOracle/BitOracle/dto/UpbitTickerResponse.java
@@ -1,0 +1,9 @@
+package com.BitOracle.BitOracle.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpbitTickerResponse {
+    private String market;
+    private String trade_price;
+}

--- a/src/main/java/com/BitOracle/BitOracle/service/MetricsService.java
+++ b/src/main/java/com/BitOracle/BitOracle/service/MetricsService.java
@@ -1,0 +1,149 @@
+package com.BitOracle.BitOracle.service;
+
+import com.BitOracle.BitOracle.dto.CoinMarketCapResponse;
+import com.BitOracle.BitOracle.dto.MetricsDto;
+import com.BitOracle.BitOracle.dto.UpbitTickerResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Collections;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MetricsService {
+
+    private final String API_KEY = "c23fdae7-d913-4577-a125-33f2f0565dd5"; // 🔐 CoinMarketCap 프로 키
+    private final String URL = "https://pro-api.coinmarketcap.com/v1/global-metrics/quotes/latest";
+
+    public MetricsDto fetchMetrics() {
+        MetricsDto marketMetrics = fetchMarketMetrics();
+        BigDecimal kimchiPremium = calculateKimchiPremium();
+
+        return MetricsDto.builder()
+                .marketCap(marketMetrics.getMarketCap())
+                .btcDominance(marketMetrics.getBtcDominance())
+                .kimchiPremium(kimchiPremium)
+                .build();
+    }
+
+    public MetricsDto fetchMarketMetrics() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-CMC_PRO_API_KEY", API_KEY);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(URL, HttpMethod.GET, entity, String.class);
+
+        try {
+            // JSON 파싱 간단 처리 (정식으로 하려면 ObjectMapper 사용)
+            String body = response.getBody();
+            String totalMarketCapStr = body.split("\"total_market_cap\":")[1].split(",")[0];
+            String btcDominanceStr = body.split("\"btc_dominance\":")[1].split(",")[0];
+
+            BigDecimal marketCap = new BigDecimal(totalMarketCapStr);
+            BigDecimal dominance = new BigDecimal(btcDominanceStr);
+
+            return MetricsDto.builder()
+                    .marketCap(marketCap)
+                    .btcDominance(dominance)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("시가총액 파싱 실패", e);
+            return null;
+        }
+    }
+
+    public BigDecimal calculateKimchiPremium() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        try {
+            // 1. 업비트 KRW-BTC 가격
+            String upbitUrl = "https://api.upbit.com/v1/ticker?markets=KRW-BTC";
+            ResponseEntity<UpbitTickerResponse[]> upbitResp =
+                    restTemplate.getForEntity(upbitUrl, UpbitTickerResponse[].class);
+
+            BigDecimal upbitPrice = new BigDecimal(upbitResp.getBody()[0].getTrade_price());
+
+            // 2. CMC BTC/USDT 가격
+            String cmcUrl = "https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=BTC&convert=USDT";
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-CMC_PRO_API_KEY", API_KEY);
+            headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<CoinMarketCapResponse> cmcResp =
+                    restTemplate.exchange(cmcUrl, HttpMethod.GET, entity, CoinMarketCapResponse.class);
+
+            String priceStr = cmcResp.getBody()
+                    .getData()
+                    .get("BTC")
+                    .getQuote()
+                    .get("USDT")
+                    .getPrice();
+
+            BigDecimal globalPrice = new BigDecimal(priceStr);
+
+            // 3. 환율
+//            BigDecimal exchangeRate = calculateUsdKrwRate();
+            BigDecimal exchangeRate = BigDecimal.valueOf(1400); // 임시 하드 코딩
+
+            // 4. 글로벌 BTC 가격 (KRW 환산)
+            BigDecimal globalPriceKrw = globalPrice.multiply(exchangeRate);
+
+            // 5. 김치 프리미엄 계산
+            BigDecimal kimchiPremium = upbitPrice.subtract(globalPriceKrw)
+                    .divide(globalPriceKrw, 4, RoundingMode.HALF_UP)
+                    .multiply(BigDecimal.valueOf(100));
+
+            log.info("🟢 업비트 BTC(KRW): {}", upbitPrice);
+            log.info("🌐 글로벌 BTC(USD): {}", globalPrice);
+            log.info("💱 환율(USD→KRW): {}", exchangeRate);
+            log.info("🌐 글로벌 BTC(KRW): {}", globalPriceKrw);
+            log.info("📊 김치 프리미엄: {}%", kimchiPremium);
+
+            return kimchiPremium;
+
+        } catch (Exception e) {
+            log.error("김치 프리미엄 계산 실패", e);
+            return BigDecimal.ZERO;
+        }
+    }
+
+    public BigDecimal calculateUsdKrwRate() {
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            // 1. 업비트 BTC/KRW 가격
+            String krwUrl = "https://api.upbit.com/v1/ticker?markets=KRW-BTC";
+            ResponseEntity<UpbitTickerResponse[]> krwResp =
+                    restTemplate.getForEntity(krwUrl, UpbitTickerResponse[].class);
+            BigDecimal krwPrice = new BigDecimal(krwResp.getBody()[0].getTrade_price());
+
+            // 2. 업비트 BTC/USDT 가격
+            String usdtUrl = "https://api.upbit.com/v1/ticker?markets=USDT-BTC";
+            ResponseEntity<UpbitTickerResponse[]> usdtResp =
+                    restTemplate.getForEntity(usdtUrl, UpbitTickerResponse[].class);
+            BigDecimal usdtPrice = new BigDecimal(usdtResp.getBody()[0].getTrade_price());
+
+            // 3. 환율 계산: KRW-BTC ÷ USDT-BTC
+            BigDecimal exchangeRate = krwPrice.divide(usdtPrice, 2, RoundingMode.HALF_UP);
+
+            log.info("🔁 간접 환율 계산: KRW-BTC = {}, USDT-BTC = {}, 환율 = {}", krwPrice, usdtPrice, exchangeRate);
+            return exchangeRate;
+
+        } catch (Exception e) {
+            log.error("환율 간접 계산 실패", e);
+            return BigDecimal.valueOf(1400); // fallback
+        }
+    }
+}

--- a/src/main/java/com/BitOracle/BitOracle/websocket/MetricsCache.java
+++ b/src/main/java/com/BitOracle/BitOracle/websocket/MetricsCache.java
@@ -1,0 +1,20 @@
+package com.BitOracle.BitOracle.websocket;
+
+import com.BitOracle.BitOracle.dto.MetricsDto;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+@Component
+public class MetricsCache {
+
+    private final AtomicReference<MetricsDto> cache = new AtomicReference<>();
+
+    public void update(MetricsDto metrics) {
+        cache.set(metrics);
+    }
+
+    public MetricsDto get() {
+        return cache.get();
+    }
+}

--- a/src/main/java/com/BitOracle/BitOracle/websocket/MetricsPublisher.java
+++ b/src/main/java/com/BitOracle/BitOracle/websocket/MetricsPublisher.java
@@ -1,0 +1,29 @@
+package com.BitOracle.BitOracle.websocket;
+
+import com.BitOracle.BitOracle.dto.MetricsDto;
+import com.BitOracle.BitOracle.service.MetricsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MetricsPublisher {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final MetricsService metricsService;
+    private final MetricsCache metricsCache;
+
+    @Scheduled(fixedRate = 10000) // 10초마다 전송
+    public void publishMetrics() {
+        MetricsDto metrics = metricsService.fetchMetrics();
+        if (metrics != null) {
+            metricsCache.update(metrics);
+            messagingTemplate.convertAndSend("/sub/metrics", metrics);
+            log.info("✅ 지표 정보 전송: {}", metrics);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #55 

## 📝작업 내용

> 시가총액, 비트코인 도미넌스, 김치 프리미엄 조회 웹 소켓 구현
메모리 캐시에 정보 저장으로 API를 통해 호출도 가능

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?